### PR TITLE
texture url patch #354

### DIFF
--- a/src/examples/texture.elm
+++ b/src/examples/texture.elm
@@ -5,5 +5,5 @@ import Graphics.Element exposing (..)
 main : Element
 main =
   collage 300 300
-    [ textured "/stripes.jpg" (ngon 5 75)
+    [ textured "/imgs/stripes.jpg" (ngon 5 75)
     ]


### PR DESCRIPTION
The current example has the wrong url for the texture. 
This patch update the url to the new location of the texture. 